### PR TITLE
Fix getopts

### DIFF
--- a/dhusget_0.3.4.sh
+++ b/dhusget_0.3.4.sh
@@ -151,7 +151,7 @@ function print_usage
  echo "   				  The format of the output file is compatible with option ${bold}-r${normal} ;"
  echo " "
  echo "   -D  				: if specified, remove the products that have failed the MD5 integrity check from disk."
- echo "   				  By deafult products are not removed;"
+ echo "   				  By default products are not removed;"
  echo " "
  echo "   -r <file>			: download the products listed in an input <file> written according to the following format:"
  echo "   				  - One product per line."

--- a/dhusget_0.3.4.sh
+++ b/dhusget_0.3.4.sh
@@ -195,7 +195,7 @@ export SENSING_TIME_TO="NOW"
 unset TIMEFILE
 
 
-while getopts ":d:u:p:l:P:q:C:m:i:t:s:e:S:E:f:c:T:o:V:h:F:R:D:r:O:N:L:n:" opt; do
+while getopts ":d:u:p:l:P:q:C:m:i:t:s:e:S:E:f:c:T:o:V:h:F:R:Dr:O:N:L:n:" opt; do
  case $opt in
 	d)
 		export DHUS_DEST="$OPTARG"

--- a/dhusget_0.3.5.sh
+++ b/dhusget_0.3.5.sh
@@ -199,7 +199,7 @@ export SENSING_TIME_TO="NOW"
 unset TIMEFILE
 
 
-while getopts ":d:u:p:l:P:q:C:m:i:t:s:e:S:E:f:c:T:o:V:h:F:R:D:r:O:N:L:n:" opt; do
+while getopts ":d:u:p:l:P:q:C:m:i:t:s:e:S:E:f:c:T:o:V:h:F:R:Dr:O:N:L:n:" opt; do
  case $opt in
 	d)
 		export DHUS_DEST="$OPTARG"

--- a/dhusget_0.3.5.sh
+++ b/dhusget_0.3.5.sh
@@ -155,7 +155,7 @@ function print_usage
  echo "   				  The format of the output file is compatible with option ${bold}-r${normal} ;"
  echo " "
  echo "   -D  				: if specified, remove the products that have failed the MD5 integrity check from disk."
- echo "   				  By deafult products are not removed;"
+ echo "   				  By default products are not removed;"
  echo " "
  echo "   -r <file>			: download the products listed in an input <file> written according to the following format:"
  echo "   				  - One product per line."


### PR DESCRIPTION
Fixes a bug that could prevent correct handling of command-line arguments to `dhusget_0.3.5.sh` and `dhusget_0.3.4.sh`.

According to the scripts documentation `-D` option has no argument eg:

    > ./dhusget_0.3.5.sh --help | grep -e '   -D' -A 1

    -D  				: if specified, remove the products that have failed the MD5 integrity check from disk.
         				  By deafult products are not removed;

When command-line arguments included `-D` option the script ingested the successive option as an argument of `-D` thereby preventing the correct options to be executed.

Example:

    > ./dhusget_0.3.5.sh -u *** -p *** \
    -r product_lists/download_products.txt \
    -D \
    -R S2_tiles/failed_downloads.txt \
    -O S2_tiles/ \
    -o product \
    -n 5

wrote in `./failed_MD5_check_list.txt` the list of products that have failed the MD5 integrity check instead of in `S2_tiles/failed_downloads.txt`; downloaded the products in the default directory `PRODUCT/` instead that in `S2_tiles/` as provided by the `-O` option.