### PR TITLE
Bugfix. Issue with shell interpreter.

### DIFF
--- a/dhusget_0.3.8.sh
+++ b/dhusget_0.3.8.sh
@@ -880,7 +880,7 @@ cat ${INPUT_FILE} | xargs -n 4 -P ${THREAD_NUMBER} sh -c 'while : ; do
 	if [ $test -eq 0 ]; then
 		echo "Manifest ${3} successfully downloaded at " `tail -2 ./logs/log.${3}.log | head -1 | awk -F"(" '\''{print $2}'\'' | awk -F")" '\''{print $1}'\''`;
 	fi;
-	[[ $test -ne 0 ]] || break;
+	[ $test -ne 0 ] || break;
 done ' 
 fi
 


### PR DESCRIPTION
This PR fixes a little bug that happened when I tried to download some Sentinel-1 scenes and I suppose other folks incurred in the same issue. The  cause is a double square bracket testing operator which isn't recognized by the _sh_, yielding a "**[[: not found**" error message (at least in Linux environment).